### PR TITLE
2.8

### DIFF
--- a/clansplus-api/pom.xml
+++ b/clansplus-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.cortezromeo.clansplus</groupId>
         <artifactId>ClansPlus</artifactId>
-        <version>2.7</version>
+        <version>2.8</version>
     </parent>
 
     <artifactId>clansplus-api</artifactId>

--- a/clansplus-implement/pom.xml
+++ b/clansplus-implement/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.cortezromeo.clansplus</groupId>
         <artifactId>ClansPlus</artifactId>
-        <version>2.7</version>
+        <version>2.8</version>
     </parent>
 
     <artifactId>clansplus-implement</artifactId>

--- a/clansplus-plugin/pom.xml
+++ b/clansplus-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.cortezromeo.clansplus</groupId>
         <artifactId>ClansPlus</artifactId>
-        <version>2.7</version>
+        <version>2.8</version>
     </parent>
 
     <artifactId>clansplus-plugin</artifactId>

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/ClansPlus.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/ClansPlus.java
@@ -336,6 +336,7 @@ public class ClansPlus extends JavaPlugin {
         new PlayerMovementListener();
         new PlayerDeathListener();
         new EntityDeathListener();
+        new InventoryCloseListener();
     }
 
     public void initSkills() {
@@ -368,9 +369,6 @@ public class ClansPlus extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        PluginDataManager.saveAllDatabase();
-        PluginDataStorage.disableStorage();
-
         try {
             if (!Bukkit.getOnlinePlayers().isEmpty()) for (Player player : Bukkit.getOnlinePlayers()) {
                 player.closeInventory();
@@ -378,6 +376,9 @@ public class ClansPlus extends JavaPlugin {
         } catch (IncompatibleClassChangeError exception) {
             // ignore it
         }
+
+        PluginDataManager.saveAllDatabase();
+        PluginDataStorage.disableStorage();
 
         log("&f--------------------------------");
         log("&c   ____ _                   ____  _           ");

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/inventory/ClanSettingsInventory.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/inventory/ClanSettingsInventory.java
@@ -10,7 +10,7 @@ import com.cortezromeo.clansplus.clan.ClanManager;
 import com.cortezromeo.clansplus.clan.subject.SetSpawn;
 import com.cortezromeo.clansplus.file.inventory.ClanSettingsInventoryFile;
 import com.cortezromeo.clansplus.language.Messages;
-import com.cortezromeo.clansplus.listener.ChatListenerHandle;
+import com.cortezromeo.clansplus.listener.ChatListenerHandler;
 import com.cortezromeo.clansplus.storage.PluginDataManager;
 import com.cortezromeo.clansplus.util.ItemUtil;
 import com.cortezromeo.clansplus.util.MessageUtil;
@@ -80,8 +80,8 @@ public class ClanSettingsInventory extends ClanPlusInventoryBase {
         if (itemCustomData.equals("setCustomName")) {
             if (ClanManager.isPlayerRankSatisfied(getOwner().getName(), playerClanData.getSubjectPermission().get(Subject.SETCUSTOMNAME))) {
                 getOwner().closeInventory();
-                if (!ChatListenerHandle.setCustomName.contains(getOwner()))
-                    ChatListenerHandle.setCustomName.add(getOwner());
+                if (!ChatListenerHandler.setCustomName.contains(getOwner()))
+                    ChatListenerHandler.setCustomName.add(getOwner());
                 MessageUtil.sendMessage(getOwner(), Messages.USING_CHAT_BOX_SET_CUSTOM_NAME.replace("%seconds%", String.valueOf(Settings.CHAT_SETTING_TIME_OUT)));
                 MessageUtil.sendMessage(getOwner(), Messages.USING_CHAT_BOX_CANCEL_USING_CHAT_BOX.replace("%word%", Settings.CHAT_SETTING_STOP_USING_CHAT_WORD));
             }
@@ -89,8 +89,8 @@ public class ClanSettingsInventory extends ClanPlusInventoryBase {
         if (itemCustomData.equals("setMessage")) {
             if (ClanManager.isPlayerRankSatisfied(getOwner().getName(), playerClanData.getSubjectPermission().get(Subject.SETMESSAGE))) {
                 getOwner().closeInventory();
-                if (!ChatListenerHandle.setMessage.contains(getOwner()))
-                    ChatListenerHandle.setMessage.add(getOwner());
+                if (!ChatListenerHandler.setMessage.contains(getOwner()))
+                    ChatListenerHandler.setMessage.add(getOwner());
                 MessageUtil.sendMessage(getOwner(), Messages.USING_CHAT_BOX_SET_MESSAGE.replace("%seconds%", String.valueOf(Settings.CHAT_SETTING_TIME_OUT)));
                 MessageUtil.sendMessage(getOwner(), Messages.USING_CHAT_BOX_CANCEL_USING_CHAT_BOX.replace("%word%", Settings.CHAT_SETTING_STOP_USING_CHAT_WORD));
             }

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/inventory/ManageMemberRankInventory.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/inventory/ManageMemberRankInventory.java
@@ -138,7 +138,7 @@ public class ManageMemberRankInventory extends ClanPlusInventoryBase {
                     fileConfiguration.getString("items.setManager." + getPlayerRankPath + ".value"),
                     fileConfiguration.getInt("items.setManager." + getPlayerRankPath + ".customModelData"),
                     fileConfiguration.getString("items.setManager." + getPlayerRankPath + ".name"),
-                    setOwnerItemLore, false), (isPlayerAManager ? "removeManager=" : "setManager=") + playerName);
+                    setManagerItemLore, false), (isPlayerAManager ? "removeManager=" : "setManager=") + playerName);
             int setManagerItemSlot = fileConfiguration.getInt("items.setManager.slot");
             inventory.setItem(setManagerItemSlot, setManagerItem);
 

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/inventory/NoClanInventory.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/inventory/NoClanInventory.java
@@ -5,7 +5,7 @@ import com.cortezromeo.clansplus.Settings;
 import com.cortezromeo.clansplus.api.enums.ItemType;
 import com.cortezromeo.clansplus.file.inventory.NoClanInventoryFile;
 import com.cortezromeo.clansplus.language.Messages;
-import com.cortezromeo.clansplus.listener.ChatListenerHandle;
+import com.cortezromeo.clansplus.listener.ChatListenerHandler;
 import com.cortezromeo.clansplus.storage.PluginDataManager;
 import com.cortezromeo.clansplus.util.ItemUtil;
 import com.cortezromeo.clansplus.util.MessageUtil;
@@ -58,8 +58,8 @@ public class NoClanInventory extends ClanPlusInventoryBase {
             getOwner().closeInventory();
         if (itemCustomData.equals("createNewClan")) {
             getOwner().closeInventory();
-            if (!ChatListenerHandle.createClan.contains(getOwner()))
-                ChatListenerHandle.createClan.add(getOwner());
+            if (!ChatListenerHandler.createClan.contains(getOwner()))
+                ChatListenerHandler.createClan.add(getOwner());
             MessageUtil.sendMessage(getOwner(), Messages.USING_CHAT_BOX_CREATE_CLAN.replace("%seconds%", String.valueOf(Settings.CHAT_SETTING_TIME_OUT)));
             MessageUtil.sendMessage(getOwner(), Messages.USING_CHAT_BOX_CANCEL_USING_CHAT_BOX.replace("%word%", Settings.CHAT_SETTING_STOP_USING_CHAT_WORD));
         }

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/AsyncPlayerChatListener.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/AsyncPlayerChatListener.java
@@ -13,9 +13,9 @@ public class AsyncPlayerChatListener implements Listener {
         Bukkit.getPluginManager().registerEvents(this, ClansPlus.plugin);
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onChat(AsyncPlayerChatEvent event) {
-        if (ChatListenerHandle.handlePlayerChat(event.getPlayer(), event.getMessage()))
+        if (ChatListenerHandler.handlePlayerChat(event.getPlayer(), event.getMessage()))
             event.setCancelled(true);
     }
 }

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/ChatListenerHandler.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/ChatListenerHandler.java
@@ -14,13 +14,17 @@ import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ChatListenerHandle {
+public class ChatListenerHandler {
 
     public static List<Player> createClan = new ArrayList<>();
     public static List<Player> setCustomName = new ArrayList<>();
     public static List<Player> setMessage = new ArrayList<>();
 
+    /*
+    handle player chat
+    */
     public static boolean handlePlayerChat(Player player, String message) {
+        // cancel using chat interacting
         if (createClan.contains(player) || setCustomName.contains(player) || setMessage.contains(player))
             if (message.equals(Settings.CHAT_SETTING_STOP_USING_CHAT_WORD)) {
                 createClan.remove(player);

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/EntityDamageListener.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/EntityDamageListener.java
@@ -72,6 +72,9 @@ public class EntityDamageListener implements Listener {
                     Damageable damageableVictim = (Damageable) event.getEntity();
                     if (damageableVictim instanceof Player victim) {
 
+                        if (shooter.getName().equals(victim.getName()))
+                            return;
+
                         if (!ClanManager.isPlayerInClan(shooter) || !ClanManager.isPlayerInClan(victim)) return;
 
                         int checkEvent = 0;

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/InventoryCloseListener.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/InventoryCloseListener.java
@@ -1,0 +1,37 @@
+package com.cortezromeo.clansplus.listener;
+
+import com.cortezromeo.clansplus.ClansPlus;
+import com.cortezromeo.clansplus.inventory.ClanPlusStorageInventoryBase;
+import com.cortezromeo.clansplus.storage.PluginDataManager;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public class InventoryCloseListener implements Listener {
+
+    public InventoryCloseListener() {
+        Bukkit.getPluginManager().registerEvents(this, ClansPlus.plugin);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        Inventory inventory = event.getInventory();
+        InventoryHolder holder = inventory.getHolder();
+
+        if (holder instanceof ClanPlusStorageInventoryBase inventoryBase) {
+/*            for (ItemStack itemStack : inventory.getContents()) {
+                if (itemStack == null)
+                    continue;
+                if (ClansPlus.nms.getCustomData(itemStack).equals("next") || ClansPlus.nms.getCustomData(itemStack).equals("previous") || ClansPlus.nms.getCustomData(itemStack).equals("noStorage"))
+                    inventory.remove(itemStack);
+                MessageUtil.devMessage(itemStack.getType().toString());
+            }
+            IClanData clanData = PluginDataManager.getClanDatabase(inventoryBase.getClanName());
+            clanData.getStorageHashMap().put(inventoryBase.getStorageNumber(), inventory);*/
+            PluginDataManager.saveClanDatabaseToStorage(inventoryBase.getClanName());
+        }
+    }
+}

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/PaperAsyncChatListener.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/listener/PaperAsyncChatListener.java
@@ -16,11 +16,11 @@ public class PaperAsyncChatListener implements Listener {
         Bukkit.getPluginManager().registerEvents(this, ClansPlus.plugin);
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onChat(AsyncChatEvent event) {
         if (Settings.CHAT_SETTING_USE_PAPER_ASYNC_CHAT) {
             TextComponent textComponent = (TextComponent) event.message();
-            if (ChatListenerHandle.handlePlayerChat(event.getPlayer(), textComponent.content()))
+            if (ChatListenerHandler.handlePlayerChat(event.getPlayer(), textComponent.content()))
                 event.setCancelled(true);
         }
     }

--- a/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/storage/PluginDataYAMLStorage.java
+++ b/clansplus-plugin/src/main/java/com/cortezromeo/clansplus/storage/PluginDataYAMLStorage.java
@@ -252,7 +252,10 @@ public class PluginDataYAMLStorage implements PluginStorage {
                 int slotNumber = -1;
                 for (ItemStack itemStack : inventoryContents.getContents()) {
                     slotNumber++;
-                    if (itemStack == null) continue;
+                    if (itemStack == null) {
+                        storage.set("data.storage." + storageNumber + "." + slotNumber, null);
+                        continue;
+                    }
                     if (ClansPlus.nms.getCustomData(itemStack).equals("next") || ClansPlus.nms.getCustomData(itemStack).equals("previous") || ClansPlus.nms.getCustomData(itemStack).equals("noStorage"))
                         continue;
                     storage.set("data.storage." + storageNumber + "." + slotNumber, StringUtil.toBase64(itemStack));

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cortezromeo.clansplus</groupId>
     <artifactId>ClansPlus</artifactId>
-    <version>2.7</version>
+    <version>2.8</version>
     <packaging>pom</packaging>
 
     <name>ClansPlus</name>


### PR DESCRIPTION
Fixed Dupe Item from Clan Storage
Fixed Set Manager Item Lore in Manager Member Rank Inventory uses the Set Owner Lore
Fixed Chat Priority
Fixed Players cannot hurt themselves using ender pearl or anything like that
Added Close Inventory Event to save clan database